### PR TITLE
Check if Virtualization is enabled in BIOS

### DIFF
--- a/Folding In Sandbox/install_folding_sandbox_on_host.ps1
+++ b/Folding In Sandbox/install_folding_sandbox_on_host.ps1
@@ -3,8 +3,14 @@ $ProgressPreference = 'SilentlyContinue' #Progress bar makes things way slower
 
 #Check Sandbox is enabled, only thing that requires administrator permissions
 Write-Output 'Checking that Windows Sandbox is installed...'
-If((Get-WindowsOptionalFeature -FeatureName 'Containers-DisposableClientVM' -Online).length -ne 1) {
-	Enable-WindowsOptionalFeature -FeatureName 'Containers-DisposableClientVM' -All -Online
+#Check if virtualization is enbaled in BIOS
+if((Get-WmiObject Win32_ComputerSystem).HypervisorPresent -eq $true){
+    If((Get-WindowsOptionalFeature -FeatureName 'Containers-DisposableClientVM' -Online).length -eq 1) {
+	    Enable-WindowsOptionalFeature -FeatureName 'Containers-DisposableClientVM' -All -Online
+    }
+}else{
+Write-Output 'Please Enable Virtualization capabilities in your BIOS settings...'
+exit
 }
 
 #Get the latest version of folding


### PR DESCRIPTION
Adding a check to see if virtualization is enabled in BIOS before enabling the sandbox feature and if not enabled will show a message to the user to enable it and exit the script