### PR TITLE
Check installer size

### DIFF
--- a/Folding In Sandbox/install_folding_sandbox_on_host.ps1
+++ b/Folding In Sandbox/install_folding_sandbox_on_host.ps1
@@ -27,12 +27,14 @@ $installer_url = 'https://download.foldingathome.org/releases/public/release/fah
 # Use regex to get the latest version from the FAH website.
 $version = ((Invoke-WebRequest -Uri $installer_url -UseBasicParsing).Links | Where-Object  {$_.href -match '^v\d+([.]\d+)?'} | ForEach-Object {[float]($_.href -replace '[^.\d]', '')} | Measure-Object -Max).Maximum
 $installer = "$($installer_url)v$($version)/latest.exe"
+$installer_size =(Invoke-WebRequest $installer -Method Head).Headers.'Content-Length'
 Write-Output "Using FAH v$version."
 
 # Check if the installer is present, download otherwise.
 $working_dir = "$env:USERPROFILE\fah_conf"
 $install_fname = 'folding_installer.exe'
-If (!(test-path "$working_dir\$install_fname")) {
+If (!(test-path "$working_dir\$install_fname") -or (Get-ChildItem "$working_dir\$install_fname").Length -ne $installer_size ) {
+	Remove-Item "$working_dir\$install_fname" -Force -ErrorAction SilentlyContinue
 	Write-Output "Downloading latest folding executable: $working_dir\$install_fname"
 	Write-Output "Saving to $working_dir\$install_fname..."
 	New-Item -ItemType Directory -Force -Path $working_dir | Out-Null


### PR DESCRIPTION
If the download of the installer has failed for some reason and the user tries to re-run the script again it will only check if the installer exists and continues execution even if the downloader is corrupt. I added a variable to get the installer size and then compares the file size if the installer already exists