### PR TITLE
Virtualization BIOS check

### DIFF
--- a/Folding In Sandbox/install_folding_sandbox_on_host.ps1
+++ b/Folding In Sandbox/install_folding_sandbox_on_host.ps1
@@ -4,23 +4,21 @@
 param([string]$username='wsandbox_anon')
 $ProgressPreference = 'SilentlyContinue' #Progress bar makes things way slower
 
-# Ensure that virtualization is enbaled in BIOS.
-Write-Output 'Verifying that virtualization is enabled in BIOS...'
-if ((Get-WmiObject Win32_ComputerSystem).HypervisorPresent -eq $false) {
-	Write-Output 'ERROR: Please Enable Virtualization capabilities in your BIOS settings...'
-	exit
-}
-
 # Determine if Windows Sandbox is enabled.
-Write-Output 'Checking to see if Windows Sandbox is installed...'
-If ((Get-WindowsOptionalFeature -FeatureName 'Containers-DisposableClientVM' -Online).State -ne 'Enabled') {
-	Write-Output 'Windows Sandbox is not installed, attempting to install it (may require reboot)...'
-	if ((Enable-WindowsOptionalFeature -FeatureName 'Containers-DisposableClientVM' -All -Online -NoRestart).RestartNeeded) {
-		Write-Output 'Please reboot to finish installing Windows Sandbox, then re-run this script...'
-		exit
+try{
+	Write-Output 'Checking to see if Windows Sandbox is installed...'
+	If ((Get-WindowsOptionalFeature -FeatureName 'Containers-DisposableClientVM' -Online).State -ne 'Enabled') {
+		Write-Output 'Windows Sandbox is not installed, attempting to install it (may require reboot)...'
+		if ((Enable-WindowsOptionalFeature -FeatureName 'Containers-DisposableClientVM' -All -Online -NoRestart).RestartNeeded) {
+			Write-Output 'Please reboot to finish installing Windows Sandbox, then re-run this script...'
+			exit
+		}
+	} else {
+		Write-Output 'Windows Sandbox already installed.' 
 	}
-} else {
-	Write-Output 'Windows Sandbox already installed.' 
+}catch{
+	Write-Output 'ERROR: Please Enable Virtualization capabilities in your BIOS settings ,then re-run this script...'
+    	exit
 }
 
 # Download the latest version of FAH.


### PR DESCRIPTION
There has been a couple of users reporting unexpected prompts even if the virtualization is enabled. Removed the check statements and added try/catch to rely on the error message generated from the installation of the sandbox feature to prompt the user to enable virtualization from  BIOS